### PR TITLE
links was missing from the tree layout

### DIFF
--- a/src/main/scala/org/singlespaced/d3js/layout.scala
+++ b/src/main/scala/org/singlespaced/d3js/layout.scala
@@ -554,7 +554,7 @@ trait Tree[T] extends js.Object {
 
   //todo:fix T must be node subtype 
   
-  def links(nodes: js.Array[T]): js.Array[tree_.Link[T]] = js.native
+  def links(nodes: js.Array[T]): js.Array[Link[T]] = js.native
   
   def children(): js.Function2[T, Double, js.Array[T]] = js.native
 

--- a/src/main/scala/org/singlespaced/d3js/layout.scala
+++ b/src/main/scala/org/singlespaced/d3js/layout.scala
@@ -547,14 +547,12 @@ trait Node extends js.Object {
 }
 
 @js.native
-trait Tree[T] extends js.Object {
+trait Tree[T <: treeModule.Node] extends js.Object {
   def apply(root: T, index: Double = ???): js.Array[T] = js.native
 
   def nodes(root: T, index: Double = ???): js.Array[T] = js.native
-
-  //todo:fix T must be node subtype 
   
-  def links(nodes: js.Array[T]): js.Array[Link[T]] = js.native
+  def links(nodes: js.Array[T]): js.Array[treeModule.Link[T]] = js.native
   
   def children(): js.Function2[T, Double, js.Array[T]] = js.native
 
@@ -655,6 +653,3 @@ trait Treemap[T <: treemapModule.Node] extends js.Object {
 
   def ratio(ratio: Double): Treemap[T] = js.native
 }
-
-
-

--- a/src/main/scala/org/singlespaced/d3js/layout.scala
+++ b/src/main/scala/org/singlespaced/d3js/layout.scala
@@ -552,7 +552,10 @@ trait Tree[T] extends js.Object {
 
   def nodes(root: T, index: Double = ???): js.Array[T] = js.native
 
-  //todo:fix T must be node subtype def links(nodes: js.Array[T]): js.Array[tree_.Link[T]] = js.native
+  //todo:fix T must be node subtype 
+  
+  def links(nodes: js.Array[T]): js.Array[tree_.Link[T]] = js.native
+  
   def children(): js.Function2[T, Double, js.Array[T]] = js.native
 
   def children(children: js.Function2[T, Double, js.Array[T]]): Tree[T] = js.native


### PR DESCRIPTION
The links function was missing from the tree layout.

It appears that it was accidentally commented out.

I have uncommented is so that it is now accessible.
